### PR TITLE
Changed implementation from using log files to using SQLite

### DIFF
--- a/people-counter/beacone/.gitignore
+++ b/people-counter/beacone/.gitignore
@@ -1,2 +1,4 @@
 *.log
 settings
+*.db
+nomlab_data.sql

--- a/people-counter/beacone/ER.md
+++ b/people-counter/beacone/ER.md
@@ -1,0 +1,30 @@
+``` mermaid
+erDiagram
+  Beacon {
+    int ID PK
+    char(36) UUID
+    int Major
+    int Minor
+    int TxPower
+    varchar(255) Description
+  }
+
+  Mediator {
+    int ID PK
+    varchar(20) UID
+    varchar(20) Room
+    double X_Coordinate
+    double Y_Coordinate
+    double Z_Coordinate
+    varchar(255) Description
+  }
+
+  Signal {
+    int ID PK
+    char(36) BeaconUUID
+    varchar(20) MediatorUID
+    int RSSI
+    datetime Timestamp
+    varchar(255) Description
+  }
+  ```

--- a/people-counter/beacone/README.md
+++ b/people-counter/beacone/README.md
@@ -3,8 +3,45 @@
 
 ## 使い方
 1. [sheetq](https://github.com/nomlab/sheetq)をインストール，認証を行い，使用可能な状態にする．
-2. 設定ファイルを作成する．
+2. Beacon テーブル，Mediator テーブルのデータ設定ファイルを作成する．
     ```bash
+    cd db
+    cp sample_data.sql data.sql
+    vim data.sql
+    ```
+    各テーブルは以下のスキーマになっているため，各環境に合わせて設定する．
+    #### Beacon テーブル
+
+    ```sql
+    CREATE TABLE Beacon(
+      ID int primary key,
+      UUID char(36),
+      Major int,
+      Minor int,
+      TxPower int,
+      Description varchar(255)
+    );
+    ```
+    #### Mediator テーブル
+
+    ```sql
+    CREATE TABLE Mediator(
+      ID int primary key,
+      UID varchar(20),
+      Room varchar(10),
+      X_Coordinate double,
+      Y_Coordinate double,
+      Z_Coordinate double,
+      Description varchar(255)
+    );
+    ```
+3. スキーマ定義ファイルとデータ設定ファイルを用いてデータベースファイルを作成する．
+   ```bash
+   sqlite3 beacone.db < schema.sql
+   sqlite3 beacone.db < data.sql
+4. 設定ファイルを作成する．
+    ```bash
+    cd ..
     cp settings.example settings
     vim settings
     ```
@@ -13,12 +50,12 @@
     * MQTT_PUB_TOPIC: 在室状態をパブリッシュするトピック名
     * MQTT_SUB_TOPIC: Mediator のログをサブスクライブするトピック名
     * INTERVAL: 何秒おきにログを確認するか
-    * LOG_FILE: ログファイルの置き場所 (空のままだと，このスクリプトと同じディレクトリに `beacon.log` というファイルが作成・使用される)
-3. そのまま動かす場合
+    * DB_FILE: ログファイルの置き場所 (空のままだと，このスクリプトと同じディレクトリの `db` ディレクトリに `beacone.db` というファイルが作成・使用される)
+5. そのまま動かす場合
     ```bash
     ./beacone.sh
     ```
-4. systemd 経由で使う / 自動起動させたい場合
+6. systemd 経由で使う / 自動起動させたい場合
     1. systemd の設定ファイルを配置する
         ```bash
         sudo cp systemd/beacone.service /etc/systemd/system/

--- a/people-counter/beacone/db/sample_data.sql
+++ b/people-counter/beacone/db/sample_data.sql
@@ -1,0 +1,25 @@
+-- Beaconテーブルのデータ
+INSERT INTO Beacon (ID, UUID, Major, Minor, TxPower, Description)
+VALUES
+('1', 'df3a8a50-01ab-4f24-8fa9-9631bc872345', 2, 300, -60, 'tanaka'),
+('2', 'f3a2b8d0-1234-4bd9-8fb8-524ae8b9056d', 2, 301, -65, 'suzuki'),
+('3', '92c377aa-4e56-485b-81e7-8fd0ecb89c12', 2, 302, -62, 'yamada'),
+('4', 'bc194b98-6f4e-41c1-b3cb-1b132b90789a', 2, 303, -64, 'kobayashi'),
+('5', '13a2e8fa-b24b-4852-b2f0-13c2cb89a123', 2, 304, -63, 'nakajima'),
+('6', '24c4e8fa-d344-4893-b3f0-15f3cb89a987', 2, 305, -61, 'matsumoto'),
+('7', '18c2e8fa-a44a-4921-b1d0-09b1cb89b098', 2, 306, -66, 'inoue'),
+('8', 'e29a32f8-c543-493d-b6a4-05b6cb89d543', 2, 307, -58, 'saito'),
+('9', 'd39e82b9-a6b4-4e57-b234-65b4cb89a543', 2, 308, -64, 'takahashi'),
+('10', '2d4f72e5-f123-4dbe-b034-75f5cb89e234', 2, 309, -65, 'kato'),
+('11', '6b3f97b9-c342-4f23-b546-45f3cb89c123', 2, 310, -63, 'murakami'),
+('12', 'a1d4e0b2-5c23-4d34-a456-55f6cb89e654', 2, 311, -67, 'ishikawa');
+
+-- Mediatorテーブルのデータ
+INSERT INTO Mediator (ID, UID, Room, X_Coordinate, Y_Coordinate, Z_Coordinate, Description)
+VALUES
+('1', 'blescanner-123abc', 'room201', 1.5, 2.0, 0.0, 'Meeting Room A'),
+('2', 'blescanner-456def', 'room202', -2.0, 1.0, 0.5, 'Office Space 1'),
+('3', 'blescanner-789ghi', 'room203', -1.0, -1.5, 0.3, 'Break Area'),
+('4', 'blescanner-101jkl', 'room204', 2.0, 2.5, 0.1, 'Conference Room'),
+('5', 'blescanner-202mno', 'room205', 0.0, 0.0, 0.0, 'Reception Area'),
+('6', 'blescanner-303pqr', 'room301', 3.0, 3.0, 0.0, 'Executive Office');

--- a/people-counter/beacone/db/schema.sql
+++ b/people-counter/beacone/db/schema.sql
@@ -1,0 +1,27 @@
+CREATE TABLE Beacon(
+  ID int primary key,
+  UUID char(36),
+  Major int,
+  Minor int,
+  TxPower int,
+  Description varchar(255)
+);
+
+CREATE TABLE Mediator(
+  ID int primary key,
+  UID varchar(20),
+  Room varchar(10),
+  X_Coordinate double,
+  Y_Coordinate double,
+  Z_Coordinate double,
+  Description varchar(255)
+);
+
+CREATE TABLE Signal (
+  ID int PRIMARY KEY,
+  BeaconUUID char(36),
+  MediatorUID varchar(20),
+  RSSI int,
+  Timestamp datetime,
+  Description varchar(255),
+);

--- a/people-counter/beacone/settings_example
+++ b/people-counter/beacone/settings_example
@@ -2,5 +2,6 @@ MQTT_HOST="mqtt.example.com"
 MQTT_PUB_TOPIC_BASE="example/pub/topic"
 MQTT_SUB_TOPIC="example/sub/topic/beacon/mediator"
 INTERVAL=30 #seconds
-LOG_FILE="/path/to/log_file.log"
-# If LOG_FILE is empty, assigned default value as "$(dirname "$0")/beacon.log"
+THRESHOLD=-73
+DB_FILE="/path/to/db_file.db"
+# If DB_FILE is empty, assigned default value as "$(dirname "$0")/db/beacone.db"


### PR DESCRIPTION
# Beacon 情報を用いた在室情報推定
各人が持つ Beacon が発する情報を MQTT で Sub し，在室情報を推定する Beacon Aggregator．

## 使い方
1. [sheetq](https://github.com/nomlab/sheetq)をインストール，認証を行い，使用可能な状態にする．
2. Beacon テーブル，Mediator テーブルのデータ設定ファイルを作成する．
    ```bash
    cd db
    cp sample_data.sql data.sql
    vim data.sql
    ```
    各テーブルは以下のスキーマになっているため，各環境に合わせて設定する．
    #### Beacon テーブル

    ```sql
    CREATE TABLE Beacon(
      ID int primary key,
      UUID char(36),
      Major int,
      Minor int,
      TxPower int,
      Description varchar(255)
    );
    ```
    #### Mediator テーブル

    ```sql
    CREATE TABLE Mediator(
      ID int primary key,
      UID varchar(20),
      Room varchar(10),
      X_Coordinate double,
      Y_Coordinate double,
      Z_Coordinate double,
      Description varchar(255)
    );
    ```
3. スキーマ定義ファイルとデータ設定ファイルを用いてデータベースファイルを作成する．
   ```bash
   sqlite3 beacone.db < schema.sql
   sqlite3 beacone.db < data.sql
4. 設定ファイルを作成する．
    ```bash
    cd ..
    cp settings.example settings
    vim settings
    ```
    設定ファイル内に以下の変数があるため，各環境に合わせて設定する．
    * MQTT_HOST: MQTT のドメイン名
    * MQTT_PUB_TOPIC: 在室状態をパブリッシュするトピック名
    * MQTT_SUB_TOPIC: Mediator のログをサブスクライブするトピック名
    * INTERVAL: 何秒おきにログを確認するか
    * DB_FILE: ログファイルの置き場所 (空のままだと，このスクリプトと同じディレクトリの `db` ディレクトリに `beacone.db` というファイルが作成・使用される)
5. そのまま動かす場合
    ```bash
    ./beacone.sh
    ```
6. systemd 経由で使う / 自動起動させたい場合
    1. systemd の設定ファイルを配置する
        ```bash
        sudo cp systemd/beacone.service /etc/systemd/system/
        sudo vim /etc/systemd/system/beacone.service
        ```
        beacone.service ファイルを各環境に合わせて設定する．
    2. (Optional) sheetq や Ruby がグローバルで使用できない場合
        ```bash
        sudo cp systemd/beacone_environment /etc/environment/
        sudo vim /etc/environment/beacone_environment
        ```
        beacone_environment ファイルに Ruby や sheetq が使えるパスを記述する．
    3. systemd から起動
        ```bash
        sudo systemctl start beacone.service
        ```
    4. (Optional) 自動起動する場合
        ```bash
        sudo systemctl enable beacone.service
        ```

## 処理内容
1. MQTTをサブスクライブし，Mediatorのデータをログファイルに記録する．
2. Google スプレッドシートから，各人の Beacon UUID を取得する．
3. ログを定期的に確認し，各人のログの情報から在室状態を判断する．
4. 在室/不在をMQTTでパブリッシュする．

## Subscribe されるデータの形式
データは以下の json 形式で受信されることが想定される．
```json
{"uuid": "aabbccdd-eeff-0011-2233-445566778899","major":1,"minor":200,"rssi":-50}
```

## Publish するデータの形式
以下の json 形式で送信する．
status は，各人が在室する部屋番号を表す．
```json
{"<account_name>" : "<status>"}
```
